### PR TITLE
put back the signeup button on the homepage

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,13 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate_user!
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    # For additional fields in app/views/devise/registrations/new.html.erb
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:prenom, :nom, :carte_t])
+
+    # For additional in app/views/devise/registrations/edit.html.erb
+    devise_parameter_sanitizer.permit(:account_update, keys: [:prenom, :nom, :carte_t])
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row mt-3">
-    <div class="col-4 offset-4">
-      <h2>Edit <%= resource_name.to_s.humanize %></h2>
+    <div class="col-6">
+      <h2>Editer mon compte <%#= resource_name.to_s.humanize %></h2>
 
       <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
         <%= f.error_notification %>
@@ -27,15 +27,18 @@
         </div>
 
         <div class="form-actions btn btn-outline-primary">
-          <%= f.button :submit, "Update" %>
+          <%= f.button :submit, "Editer" %>
         </div>
       <% end %>
-
-      <h3 class="mt-5">Supprimer mon compte</h3>
-
-      <p><%= link_to "Supprimer mon compte", registration_path(resource_name), data: { confirm: "Vraiment? 😟" }, method: :delete %></p>
-
-      <p class="btn btn btn-outline-secondary btn-lg"><%= link_to "Back", :back %></p>
     </div>
+      <div class="col-6 pl-5">
+        <h3>Supprimer mon compte</h3>
+          <p><%= link_to "Supprimer mon compte", registration_path(resource_name), data: { confirm: "Vraiment? 😟" }, method: :delete %></p>
+      </div>
+  </div>
+</div>
+<div class="container">
+  <div class="row mt-3">
+      <p class="btn btn btn-outline-secondary btn-block"><%= link_to "Back", :back %></p>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,6 +10,18 @@
                       required: true,
                       autofocus: true,
                       input_html: { autocomplete: "email" }%>
+          <%= f.input :prenom,
+                      required: true,
+                      autofocus: true,
+                      input_html: { autocomplete: "prenom" }%>
+          <%= f.input :nom,
+                      required: true,
+                      autofocus: true,
+                      input_html: { autocomplete: "nom" }%>
+          <%= f.input :carte_t,
+                      required: true,
+                      autofocus: true,
+                      input_html: { autocomplete: "carte_t" }%>
           <%= f.input :password,
                       required: true,
                       hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row mt-3">
     <div class="col-4 offset-4">
-      <h2>Sign up</h2>
+      <h2>Créer un compte</h2>
       <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <%= f.error_notification %>
 
@@ -20,7 +20,7 @@
         </div>
 
         <div class="form-actions btn btn-outline-primary mb-5">
-          <%= f.button :submit, "Sign up" %>
+          <%= f.button :submit, "Créer un compte" %>
         </div>
       <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -30,8 +30,7 @@
                       required: true,
                       input_html: { autocomplete: "new-password" } %>
         </div>
-
-        <div class="form-actions btn btn-outline-primary mb-5">
+        <div class="form-actions btn btn-outline-primary mb-1">
           <%= f.button :submit, "Créer un compte" %>
         </div>
       <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -24,14 +24,16 @@
           <%= image_tag "https://res.cloudinary.com/agazielly/image/upload/v1566378875/jack-finnigan-rriAI0nhcbc-unsplash_vpmxjo.jpg", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
             <%= link_to "Mon dashboard", "#", class: "dropdown-item" %>
-            <%= link_to "Mon abonnement", "#", class: "dropdown-item" %>
             <%= link_to "Mon compte", edit_user_registration_path, class: "dropdown-item" %>
             <%= link_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
           </div>
         </li>
       <% else %>
         <li class="nav-item">
-          <%= link_to "Login", new_user_session_path, class: "nav-link" %>
+          <%= link_to "Créer un compte", new_user_registration_path, class: "nav-link" %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "Se connecter", new_user_session_path, class: "nav-link" %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Please find added the signeup form on the homepage.
+ a brand new style for the account edit form
+ french language for the login and signeup

I have also deleted the  <%= link_to "Mon abonnement", "#", class: "dropdown-item" %>
as there is no page for Mon Abonnement so far