### PR TITLE
Change selection button

### DIFF
--- a/app/assets/stylesheets/components/_cards-list.scss
+++ b/app/assets/stylesheets/components/_cards-list.scss
@@ -95,6 +95,6 @@
 
 .flex5 {
   position: absolute;
-  right: 5px;
-  margin-top: 30px;
+  right: 10px;
+  // margin-top: 30px;
 }

--- a/app/assets/stylesheets/components/_favorite.scss
+++ b/app/assets/stylesheets/components/_favorite.scss
@@ -1,0 +1,9 @@
+.far,
+.fas {
+  color: $jungle;
+}
+
+.far:hover,
+.fas:hover {
+  color: $jungle-hover;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -3,9 +3,10 @@
 @import "avatar";
 @import "banner";
 @import "button";
-@import "navbar";
-@import "cards-list";
-@import "map";
 @import "card-dropdown-tabs";
+@import "cards-list";
+@import "favorite";
 @import "fullpage";
+@import "map";
+@import "navbar";
 

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -2,6 +2,7 @@
 
 $dark-grey: #31333B;
 $jungle: #00C29A;
+$jungle-hover: #04a785;
 
 // For example:
 $red: #FD1015;

--- a/app/assets/stylesheets/pages/_appartements.scss
+++ b/app/assets/stylesheets/pages/_appartements.scss
@@ -198,6 +198,19 @@ color: #495057;
 
 }
 
+// SELECTION BUTTON
 
+.selection-appartement .btn-flat {
+  position: absolute;
+  right: 180px;
+  top: 50px;
+  border: 1px solid $jungle;
+  color: $jungle;
+  text-decoration: none;
+}
+
+.selection-appartement .btn-flat a {
+  color: $jungle;
+}
 
 

--- a/app/views/appartements/index.html.erb
+++ b/app/views/appartements/index.html.erb
@@ -2,7 +2,7 @@
 <%= render 'shared/banner' %>
   <div class="selection-appartement">
     <div class="btn btn-flat">
-      <%= link_to "Voir la sélection", selections_path %> <i class="fas fa-star"></i>
+      <%= link_to "Voir la sélection", selections_path %> - <%= current_user.selections.count %> <i class="fas fa-star"></i>
     </div>
   </div>
 

--- a/app/views/appartements/index.html.erb
+++ b/app/views/appartements/index.html.erb
@@ -1,5 +1,10 @@
 <div class="navbar-container">
 <%= render 'shared/banner' %>
+  <div class="selection-appartement">
+    <div class="btn btn-flat">
+      <%= link_to "Voir la sélection", selections_path %> <i class="fas fa-star"></i>
+    </div>
+  </div>
 
   <div class="container-search-bar" style="position: absolute">
     <%= form_tag appartements_path, class: "form-total d-flex justify-content-center align-item", method: :get do %>
@@ -42,6 +47,7 @@
       </select>
       </div>
 
+
       <div>
        <select class="select2 select2-typologie" name="piece[]" multiple style="width: 100%">
         <% Appartement::PIECES.each do |piece| %>
@@ -65,7 +71,6 @@
   <div class="d-flex">
 
     <div class="left-side">
-      <div class="btn btn-ghost"><%= link_to "Voir la sélection", selections_path %></div>
       <div class="container-card">
 
       <% @appartements.each do |appartement|%>

--- a/app/views/shared/_custom_switch.html.erb
+++ b/app/views/shared/_custom_switch.html.erb
@@ -1,7 +1,7 @@
 <div>
   <% if current_user.selections.where(appartement_id: appartement.id) == []%>
-    <%= link_to "◻️", appartement_selections_path(appartement), method: :post %>
+    <%= link_to "", appartement_selections_path(appartement), method: :post, class: "far fa-star" %>
     <% else %>
-    <%= link_to "✅", selection_path(current_user.selections.where(appartement_id: appartement.id)[0]), method: :delete %>
+    <%= link_to "", selection_path(current_user.selections.where(appartement_id: appartement.id)[0]), method: :delete, class: "fas fa-star"  %>
     <% end %>
   </div>


### PR DESCRIPTION
Updated the following:
- Change the card selection icons to a empty/plain star with the jungle color
- Reposition the favorite icon to the top right of the product-card

- Change the button to access to the selection and repositioned it
- Added the count on the number of selected items.

<img width="186" alt="image" src="https://user-images.githubusercontent.com/52154648/64067034-abcf7e00-cc21-11e9-8cbe-76d7cb6825ec.png">

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/52154648/64067040-c0137b00-cc21-11e9-99da-6b5b2aba8799.png">
