### PR TITLE
add sticky position to the navbar

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -7,6 +7,12 @@
   flex-grow: 0;
 }
 
+.navbar-home {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
 // .navbar-hubstone .nav-item {
 //   padding-right: 10px;
 // }

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,4 +1,4 @@
-<div class="navbar navbar-expand-sm navbar-light navbar-hubstone">
+<div class="navbar navbar-expand-sm navbar-light navbar-hubstone <%= "navbar-home" if params[:action] == "home" %>">
   <%= link_to "/", class: "navbar-brand" do %>
     <%= image_tag "https://res.cloudinary.com/agazielly/image/upload/c_crop,h_150,w_500/v1566903122/Hubstone_ogfubl.png" %>
   <% end %>


### PR DESCRIPTION
The navbar on the home stays at the top of the homepage

<img width="1437" alt="Capture d’écran 2019-09-02 à 12 15 37" src="https://user-images.githubusercontent.com/51952642/64107740-79399880-cd7b-11e9-8959-bc92fa910b8a.png">